### PR TITLE
add table layout in css

### DIFF
--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -240,6 +240,7 @@ table {
   width: 100%;
   border: 1px solid #e5e5e5;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 td,
 th {


### PR DESCRIPTION
Without this a table does not stay within Firefox’s browser window.